### PR TITLE
bugfix: Allow updating -s

### DIFF
--- a/stringtie.cpp
+++ b/stringtie.cpp
@@ -1190,7 +1190,7 @@ void processOptions(GArgs& args) {
 	 s=args.getOpt('s');
 	 if (!s.is_empty()) {
 		 singlethr=(float)s.asDouble();
-		 if (readthr<0.001 && !mergeMode) {
+		 if (singlethr<0.001) {
 			 GError("Error: invalid -s value, must be >=0.001)\n");
 		 }
 	 }

--- a/stringtie.cpp
+++ b/stringtie.cpp
@@ -1186,7 +1186,6 @@ void processOptions(GArgs& args) {
 
 	 tmpfname=args.getOpt('o');
 
-	 // coverage saturation no longer used after version 1.0.4; left here for compatibility with previous versions
 	 s=args.getOpt('s');
 	 if (!s.is_empty()) {
 		 singlethr=(float)s.asDouble();


### PR DESCRIPTION
Hello, and thanks for StringTie!

Due to what seems to be a copy-paste error that checks the wrong variable, setting -s always fails.

~~Also, there's an ominous comment about `// coverage saturation no longer used after version 1.0.4; left here for compatibility with previous versions` in the vacinity. Does this mean singlethr is not used anymore, or is this a remnant of some other code or arg?~~ After looking at git blame, this seems obsolete so I've removed it

Best,
K